### PR TITLE
fix various errors and warnings seen on clang and gcc

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -287,7 +287,7 @@ jobs:
           cd .. && \
           rm -rf libffi-3.4.6
         CIBW_ENVIRONMENT_PASS_LINUX: CFLAGS  # ensure that the build container can see our overridden build config
-        CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.manylinux_img || '' }}
+        CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.manylinux_img || 'manylinux_2_28' }}
         CIBW_MANYLINUX_I686_IMAGE: ${{ matrix.manylinux_img || '' }}
         CIBW_MANYLINUX_AARCH64_IMAGE: ${{ matrix.manylinux_img || '' }}
         CIBW_MANYLINUX_PPC64LE_IMAGE: ${{ matrix.manylinux_img || '' }}

--- a/src/c/_cffi_backend.c
+++ b/src/c/_cffi_backend.c
@@ -4753,7 +4753,7 @@ static PyObject *get_unique_type(CTypeDescrObject *x,
     */
     PyObject *key, *y;
 
-    key = PyBytes_FromStringAndSize(unique_key, keylength * sizeof(void *));
+    key = PyBytes_FromStringAndSize((const char *)unique_key, keylength * sizeof(void *));
     if (key == NULL) {
         Py_DECREF(x);
         return NULL;
@@ -4773,7 +4773,7 @@ static void remove_dead_unique_reference(PyObject *unique_key)
 {
     PyObject *wr;
     PyObject *tmp = NULL;
-    int err;
+    int err = 0;
 
     LOCK_UNIQUE_CACHE();
     /* We need to check that it's not already been replaced by a live weakref

--- a/src/c/realize_c_type.c
+++ b/src/c/realize_c_type.c
@@ -50,7 +50,7 @@ static int init_global_types_dict(PyObject *ffi_type_dict)
         return -1;
     g_ct_chararray = (CTypeDescrObject *)ct2;
 
-    g_ct_int = get_primitive_type(_CFFI_PRIM_INT);         // 'int'
+    g_ct_int = (CTypeDescrObject *)get_primitive_type(_CFFI_PRIM_INT);    // 'int'
     if (g_ct_int == NULL)
         return -1;
 
@@ -370,7 +370,7 @@ _realize_c_struct_or_union(builder_c_t *builder, int sindex)
     if (sindex == _CFFI__IO_FILE_STRUCT) {
         /* returns a single global cached opaque type */
         Py_INCREF(g_file_struct);
-        return g_file_struct;
+        return (PyObject *)g_file_struct;
     }
 
     s = &builder->ctx.struct_unions[sindex];


### PR DESCRIPTION
Fixes #3.

In addition to the issues building on gcc reported in #3, also fixes a possible use of an uninitialized variable in `remove_dead_unique_reference` spotted by clang.